### PR TITLE
Changing the documentation on how to backup

### DIFF
--- a/docs/admin_guides/docker_admin.md
+++ b/docs/admin_guides/docker_admin.md
@@ -131,27 +131,6 @@ docker-compose logs --tail 5 -f seat-app
 ## Database Backups and Restore
 
 Backups. They are important and really simple to do.
-Before you are doing the backup you should do a modification to your 
-`docker-compose.yml` this will prevent errors you will get while 
-backuping.
-
-Open up the `docker-compose.yml` look for volumes and add this line:
-```bash
- mariadb:
- volumes:
-      - "mariadb-data:/var/lib/mysql"
-      - "./my.cnf:/etc/mysql/my.cnf" # <- add this
-```
-Now you need to create a `my.cnf` file in the docker directory.
-```bash
-#my.cnf increase the values if you get a timeout error
-[mysqld]
-max_allowed_packet      = 1300M
-net_read_timeout        = 7200
-net_write_timeout       = 7200
-[mysqldump]
-max_allowed_packet      = 1300M
-```
 
 To perform a backup of the current database used within the docker stack, 
 compressing and saving it to a file called `seat_backup.sql.gz`, run:
@@ -162,11 +141,8 @@ docker-compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE"
 seat_backup.sql.gz
 ```
 
-Before restoring you should do the same modifications if you are on a new 
-server. (Modifying the `docker-compose.yml` and adding the `my.cnf`)
 
-Additionally you should create two sql files which will save you time 
-restoring your backup they should be called `start.sql` and `end.sql`.
+Before you are planning to restore your database you should create two sql files which will save you time  these files should be called `start.sql` and `end.sql`.
 
 `start.sql:`
 ```sql

--- a/docs/admin_guides/docker_admin.md
+++ b/docs/admin_guides/docker_admin.md
@@ -1,46 +1,73 @@
-![SeAT](https://i.imgur.com/aPPOxSK.png)
-
 # Docker Administration
 
-Occasionally you will need to perform administrative tasks in your SeAT instance running within docker. Be it because you would like to configure TLS for the web interface, change the port of the SeAT webserver or simply generate an admin login URL, this guide aims to help you get familiar for the commands needed for this.
+Occasionally you will need to perform administrative tasks in your SeAT 
+instance running within docker. Be it because you would like to configure 
+TLS for the web interface, change the port of the SeAT webserver or simply 
+generate an admin login URL, this guide aims to help you get familiar for 
+the commands needed for this.
 
-Many of the commands are exactly the same as those used in a bare metal installation, except for the fact that they are always prefixed with `docker-compose` and run from the same directory that you have the seat `docker-compose.yml` file stored. If your `docker-compose.yml` lives in `/opt/seat-docker`, you will need to `cd` to that directory first and then execute the `docker-compose` commands.
+Many of the commands are exactly the same as those used in a bare metal 
+installation, except for the fact that they are always prefixed with 
+`docker-compose` and run from the same directory that you have the seat 
+`docker-compose.yml` file stored. If your `docker-compose.yml` lives in 
+`/opt/seat-docker`, you will need to `cd` to that directory first and then 
+execute the `docker-compose` commands.
 
 ## Container Status
 
-For a quick, birds-eye view on the status of the containers within the SeAT docker stack, the following command may be run:
+For a quick, birds-eye view on the status of the containers within the 
+SeAT docker stack, the following command may be run:
 
 ```bash
 docker-compose ps
 ```
 
-This should give you the name, entry point, current status and internal ports used within the docker network as output.
+This should give you the name, entry point, current status and internal 
+ports used within the docker network as output.
 
 ## Admin Login
 
-Administrative access to SeAT has changed dramatically since version 3. It is no longer possible to login using a traditional username and password combination, but instead only using EVE Online SSO. 
+Administrative access to SeAT has changed dramatically since version 3. It 
+is no longer possible to login using a traditional username and password 
+combination, but instead only using EVE Online SSO. 
 
-It is possible to gain access to an administrator user via a one time generated login URL. Run the following command to generate an admin login URL:
+It is possible to gain access to an administrator user via a one time 
+generated login URL. Run the following command to generate an admin login 
+URL:
 
 ```bash
 docker-compose exec seat-app php artisan seat:admin:login
 ```
 
-This will generate an admin user with the necessary roles as well as produce a URL you can use to login to your SeAT instance as an administrator.
+This will generate an admin user with the necessary roles as well as 
+produce a URL you can use to login to your SeAT instance as an 
+administrator.
 
 !!! warning
-    If your instance shows the URL as *http://localhost/auth/login/admin/RANDOM__TOKEN* it means that you have not yet configured the URL where your SeAT instance is accessible from in the `.env` file. In this case, just copy the part after the `/auth` (with the token) into your browsers URL bar and submit the request to login.
+    If your instance shows the URL as 
+*http://localhost/auth/login/admin/RANDOM__TOKEN* it means that you have 
+not yet configured the URL where your SeAT instance is accessible from in 
+the `.env` file. In this case, just copy the part after the `/auth` (with 
+the token) into your browsers URL bar and submit the request to login.
 
 !!! note
-    Generally, you would probably only do this once and then add your EVE Online character to the Superusers role for future use.
+    Generally, you would probably only do this once and then add your EVE 
+Online character to the Superusers role for future use.
 
 ## Configuration Changes
 
-A dockerized installation of SeAT is primarily configured via a configuration file located at `.env`. Configuration options such as your applications SSO secrets, SeAT's web server ports are amongst the many configuration options available in this file.
+A dockerized installation of SeAT is primarily configured via a 
+configuration file located at `.env`. Configuration options such as your 
+applications SSO secrets, SeAT's web server ports are amongst the many 
+configuration options available in this file.
 
-Making changes to this file requires the docker stack to be restarted so that the configuration may be applies. An example case would be when you [configure SSO](/configuration/esi_configuration/) for your instance.
+Making changes to this file requires the docker stack to be restarted so 
+that the configuration may be applies. An example case would be when you 
+[configure SSO](/configuration/esi_configuration/) for your instance.
 
-Once you have made a configuration change, save the `.env` file and restart the stack by simply running the following command from the path where the `docker-compose.yml` lives:
+Once you have made a configuration change, save the `.env` file and 
+restart the stack by simply running the following command from the path 
+where the `docker-compose.yml` lives:
 
 ```bash
 docker-compose up -d
@@ -48,7 +75,10 @@ docker-compose up -d
 
 ## Live Container Logs
 
-Getting an idea of what is happening inside of the containers may be useful for many things, including debugging any issues that may occur. All of the containers generate logs that can be viewed either in isolation, or all of the containers in the stack.
+Getting an idea of what is happening inside of the containers may be 
+useful for many things, including debugging any issues that may occur. All 
+of the containers generate logs that can be viewed either in isolation, or 
+all of the containers in the stack.
 
 To view a single containers logs (`seat-app` in this examples case), run:
 
@@ -62,13 +92,23 @@ To view all containers logs at once, run:
 docker-compose logs --tail 10 -f
 ```
 
-Once you are done viewing the output, simply pressing ^C will exit the log viewer.
+Once you are done viewing the output, simply pressing ^C will exit the log 
+viewer.
 
 ## Installing Plugins
 
-SeAT provides the ability for third party developers to integrate with the core environment to extend its features and functionality. It is possible to install those plugins in a docker environment. Installing a plugin is relatively easy too. All you need to do is add the plugin name to your `SEAT_PLUGINS` variable in the `.env` file and run `docker-compose up -d` again. The plugin will be read from the `.env` file and installed as the application container starts.
+SeAT provides the ability for third party developers to integrate with the 
+core environment to extend its features and functionality. It is possible 
+to install those plugins in a docker environment. Installing a plugin is 
+relatively easy too. All you need to do is add the plugin name to your 
+`SEAT_PLUGINS` variable in the `.env` file and run `docker-compose up -d` 
+again. The plugin will be read from the `.env` file and installed as the 
+application container starts.
 
-For example. Open the `.env` file (which is most probably at `/opt/seat-docker/.env`) and edit the `SEAT_PLUGINS` variable to include the package you want to install. In our example we use the pseudo package called user/seat-plugin:
+For example. Open the `.env` file (which is most probably at 
+`/opt/seat-docker/.env`) and edit the `SEAT_PLUGINS` variable to include 
+the package you want to install. In our example we use the pseudo package 
+called user/seat-plugin:
 
 ```yaml
 # SeAT Plugins
@@ -78,7 +118,9 @@ For example. Open the `.env` file (which is most probably at `/opt/seat-docker/.
 SEAT_PLUGINS=user/seat-plugin
 ```
 
-Save your `.env` file and run `docker-compose up -d` to restart the stack with the new plugins as part of it. Depending on how big the plugin itself may be, this could take a few moments to complete.
+Save your `.env` file and run `docker-compose up -d` to restart the stack 
+with the new plugins as part of it. Depending on how big the plugin itself 
+may be, this could take a few moments to complete.
 
 You can monitor the installation process by running:
 
@@ -88,21 +130,78 @@ docker-compose logs --tail 5 -f seat-app
 
 ## Database Backups and Restore
 
-Backups. They are important and really simple to do. To perform a backup of the current database used within the docker stack, compressing and saving it to a file called `seat_backup.sql.gz`, run:
+Backups. They are important and really simple to do.
+Before you are doing the backup you should do a modification to your 
+`docker-compose.yml` this will prevent errors you will get while 
+backuping.
+
+Open up the `docker-compose.yml` look for volumes and add this line:
+```bash
+ mariadb:
+ volumes:
+      - "mariadb-data:/var/lib/mysql"
+      - "./my.cnf:/etc/mysql/my.cnf" # <- add this
+```
+Now you need to create a `my.cnf` file in the docker directory.
+```bash
+#my.cnf increase the values if you get a timeout error
+[mysqld]
+max_allowed_packet      = 1300M
+net_read_timeout        = 7200
+net_write_timeout       = 7200
+[mysqldump]
+max_allowed_packet      = 1300M
+```
+
+To perform a backup of the current database used within the docker stack, 
+compressing and saving it to a file called `seat_backup.sql.gz`, run:
 
 ```bash
-docker-compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"' | gzip > seat_backup.sql.gz
+docker-compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE" 
+-u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -skip-extended-insert' | gzip > 
+seat_backup.sql.gz
+```
+
+Before restoring you should do the same modifications if you are on a new 
+server. (Modifying the `docker-compose.yml` and adding the `my.cnf`)
+
+Additionally you should create two sql files which will save you time 
+restoring your backup they should be called `start.sql` and `end.sql`.
+
+`start.sql:`
+```sql
+SET autocommit=0;
+SET unique_checks=0;
+SET foreign_key_checks=0;
+```
+
+`end.sql:`
+```sql
+COMMIT;
+SET unique_checks=1;
+SET foreign_key_checks=1;
+SET autocommit=1;`
 ```
 
 To restore a backup to a new dockerized instance of SeAT, run:
 
 ```bash
-zcat seat_backup.sql.gz | docker-compose exec -T mariadb sh -c 'exec mysql "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"'
+ (cat start.sql ; zcat seat_backup.sql.gz  ;  cat end.sql ) | 
+docker-compose exec -T mariadb sh -c 'exec mysql  --force 
+"$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"
 ```
+
+Now you can delete  `start.sql` and `end.sql` files.
+
 
 ## Performing Updates
 
-As expected, updates for SeAT are deployed via Dockerhub and the images within the [eveseat organization](https://hub.docker.com/u/eveseat/dashboard/). Every package version release will automatically start the build process to generate a new docker image. This means updates are suuuper simple in the docker world. To update your instance, simply run:
+As expected, updates for SeAT are deployed via Dockerhub and the images 
+within the [eveseat 
+organization](https://hub.docker.com/u/eveseat/dashboard/). Every package 
+version release will automatically start the build process to generate a 
+new docker image. This means updates are suuuper simple in the docker 
+world. To update your instance, simply run:
 
 ```bash
 # Update to the latest dockerhub images
@@ -116,4 +215,6 @@ docker image prune -f
 ```
 
 !!! info "Better safe then sorry"
-    **Always** perform a [backup](#database-backups-and-restore) of your database before doing an update. Always.
+    **Always** perform a [backup](#database-backups-and-restore) of your 
+database before doing an update. Always.
+

--- a/docs/installation/docker_installation.md
+++ b/docs/installation/docker_installation.md
@@ -100,9 +100,14 @@ Next, download the docker `.env` file with:
 curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/docker-compose/.env -o .env 
 ```
 
+Next, download the docker `my.cnf`  file with:
+```bash
+curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/docker-compose/my.cnf -o  my.cnf
+```
+
 !!! warning
 
-    The location of the `docker-compose.yml` and `.env` files are important. You need to `cd` back to the directory where these are stored in order to be able to execute commands for this stack at a later stage.
+    The location of the `docker-compose.yml`,` my.cnf`  and `.env` files are important. You need to `cd` back to the directory where these are stored in order to be able to execute commands for this stack at a later stage.
 
 With the configuration files ready, start up the stack with:
 


### PR DESCRIPTION
The explanation on how to backup and restore does not work when your seat instance is getting bigger which is happening pretty fast. So I modified the documentation so that backuping and restoring still works with big databases.
 