### PR TITLE
Update requirements.md

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -77,7 +77,7 @@ If you already have it installed, check your current version with `docker versio
 | Type           | Requirement                                              | Version Check            |
 | -------------- | -------------------------------------------------------- | ------------------------ |
 | Docker         | [Docker: ^18.0](https://www.docker.com/)                 | `docker -v`              |
-| Docker Compose | [Docker compose: ^1.20](https://docs.docker.com/compose/)| `docker-compose version` |
+| Docker Compose | [Docker compose: ^1.26](https://docs.docker.com/compose/)| `docker-compose version` |
 
 !!! info
 


### PR DESCRIPTION
The upgrade instructions at https://eveseat.github.io/docs/upgrading/from_seat_3_0/docker/ state:
> Upgrade your docker-compose installation. It should be version 1.26 and up.

Yet the requirements page only states version 1.20 is required.