### PR TITLE
Update upgrade instructions to include the down

### DIFF
--- a/docs/upgrading/general.md
+++ b/docs/upgrading/general.md
@@ -16,7 +16,10 @@ This means updates are super simple in the docker world. To update your instance
 # Update to the latest dockerhub images
 docker-compose pull
 
-# Apply the updates to your instllation
+# (Optional) Take the stack down - This applies if the docker images has not been updated but you expect plugin updates
+docker-compose down
+
+# Apply the updates to your installation
 docker-compose up -d
 
 # Cleanup any dangling images


### PR DESCRIPTION
In some scenarios it makes sense to also down the stack as part of this. Specifically when plugins are updated but not the image itself, as the container will still always pull the latest plugins on restart, but if container has no new image, no restart will happen with docker-compose up only.

Also fixes a minor spelling mistake I noticed while making this edit.