### PR TITLE
add missing quotes to tabs

### DIFF
--- a/docs/admin_guides/docker_admin.md
+++ b/docs/admin_guides/docker_admin.md
@@ -32,7 +32,7 @@ docker-compose up -d
 
 Getting an idea of what is happening inside of the containers may be useful for many things, including debugging any issues that may occur. All of the containers generate logs that can be viewed either in isolation, or all of the containers in the stack.
 
-=== Docker (SeAT 4.x)
+=== "Docker (SeAT 4.x)"
 
     To view a single services' logs (`seat-web` in this examples case), run:
     
@@ -42,7 +42,7 @@ Getting an idea of what is happening inside of the containers may be useful for 
 
     All services can referenced by their name using `docker-compose`. You can see the service names [here](https://github.com/eveseat/seat-docker/blob/master/docker-compose.yml). At the time of writing this doc, the available services were: `mariadb`, `redis`, `traefik`, `seat-web`, `seat-worker` and `seat-cron`.
 
-=== Docker (SeAT 5.x)
+=== "Docker (SeAT 5.x)"
 
     To view a single services' logs (`front` in this examples case), run:
     
@@ -66,7 +66,7 @@ While most processes will output information to stdout (which is what you will s
 
 ### Logs - Web UI
 
-=== Docker (SeAT 4.x)
+=== "Docker (SeAT 4.x)"
 
     If you are getting HTTP 500's, or other exception when using the web interface, the best place to find the relevant logs will be in the `seat-web` service, in the `/var/www/seat/storage/logs` directory. To reach them, run `docker-compose exec seat-web bash`. This will drop you into bash shell in the container:
     
@@ -75,7 +75,7 @@ While most processes will output information to stdout (which is what you will s
     root@9aff5b002ca0:/var/www/seat#
     ```
 
-=== Docker (SeAT 5.x)
+=== "Docker (SeAT 5.x)"
 
     If you are getting HTTP 500's, or other exception when using the web interface, the best place to find the relevant logs will be in the `front` service, in the `/var/www/seat/storage/logs` directory. To reach them, run `docker-compose exec front bash`. This will drop you into bash shell in the container:
     
@@ -94,7 +94,7 @@ This directory should have daily log files for you to view.
 
 ### Logs - Worker / Updaters
 
-=== Docker (SeAT 4.x)
+=== "Docker (SeAT 4.x)"
 
     If you think your workers may be causing some exceptions, or you want to investigate why they may be failing, you can do so in the `seat-worker` service. Just like for the web UI, get a bash shell and cd to the logs directory.
     
@@ -105,7 +105,7 @@ This directory should have daily log files for you to view.
     eseye-2020-08-23.log
     ```
 
-=== Docker (SeAT 5.x)
+=== "Docker (SeAT 5.x)"
 
     If you think your workers may be causing some exceptions, or you want to investigate why they may be failing, you can do so in the `worker` service. Just like for the web UI, get a bash shell and cd to the logs directory.
     

--- a/docs/community_packages.md
+++ b/docs/community_packages.md
@@ -70,19 +70,19 @@ SEAT_PLUGINS=denngarr/seat-fitting,cryptaeve/seat-squad-sync
 
 - Once you have entered the package(s) to be installed run the below command in `/opt/seat-docker`:
 
-=== Docker (SeAT 4.x)
+=== "Docker (SeAT 4.x)"
     
     ```bash
     docker-compose up -d
     ```
 
-=== Docker (SeAT 5.x - using Traefik)
+=== "Docker (SeAT 5.x - using Traefik)"
 
     ```bash
     docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
     ```
 
-=== Docker (SeAT 5.x - using reverse proxy)
+=== "Docker (SeAT 5.x - using reverse proxy)"
 
     ```bash
     docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
@@ -165,7 +165,7 @@ This NodeBB plugin allows users login/register via their EVE SeAT account.
 
 Sometimes it can be useful to install a version different from the latest version, for example if you want to install an older version of a plugin or if you want to test a bugfix. The easiest way to find all available versions is to go to the packagist site of the plugin by clicking on the version in the available plugins list. On packagist, if you scroll down, to the right you will find a list of all available versions.
 
-=== Blade
+=== "Blade"
 
     Follow the normal installation steps, but change the `composer require` command to include the package according to the following example:
 
@@ -173,7 +173,7 @@ Sometimes it can be useful to install a version different from the latest versio
     sudo -H -u www-data bash -c 'composer require <package vendor>/<package-name>:<version-name>'
     ```
 
-=== Docker (SeAT 4.x)
+=== "Docker (SeAT 4.x)"
 
     In your `.env` file, add the version to the package like this:
     
@@ -187,7 +187,7 @@ Sometimes it can be useful to install a version different from the latest versio
     docker-compose up -d
     ```
 
-=== Docker (SeAT 5.x - using Traefik)
+=== "Docker (SeAT 5.x - using Traefik)"
 
     In your `.env` file, add the version to the package like this:
     
@@ -201,7 +201,7 @@ Sometimes it can be useful to install a version different from the latest versio
     docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
     ```
 
-=== Docker (SeAT 5.x - using proxy)
+=== "Docker (SeAT 5.x - using proxy)"
 
     In your `.env` file, add the version to the package like this:
     

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -34,7 +34,7 @@ An example of adding these to your Web UI container is provided below:
 * Creating `docker-compose.override.yml` in `/opt/seat-docker/` directory
 * Adding following code to `docker-compose.override.yml` Note: Uncomment the needed file(s) by removing the `#`
 
-=== SeAT 4
+=== "SeAT 4"
 
     ```YAML linenums="1"
     version: "3.2"
@@ -49,7 +49,7 @@ An example of adding these to your Web UI container is provided below:
 
     Once you have placed the files you will need to run `docker-compose up -d` for it to take effect.
 
-=== SeAT 5 (using Traefik)
+=== "SeAT 5 (using Traefik)"
 
     ```YAML linenums="1"
     version: "3.2"
@@ -64,7 +64,7 @@ An example of adding these to your Web UI container is provided below:
 
     Once you have placed the files you will need to run `docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up` for it to take effect.
 
-=== SeAT 5 (using proxy)
+=== "SeAT 5 (using proxy)"
 
     ```YAML linenums="1"
     version: "3.2"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,13 +72,13 @@ Application source code and log files are shared between the `seat-web`/`front`,
 
 First, enter get a shell within the `seat-web`/`front` container while in the `/opt/seat-docker/` directory with:
 
-=== SeAT 4.x
+=== "SeAT 4.x"
 
     ```bash
     docker-compose exec seat-web sh
     ```
 
-=== SeAT 5.x
+=== "SeAT 5.x"
 
     ```bash
     docker-compose exec front sh
@@ -114,13 +114,13 @@ su -c 'php artisan seat:admin:diagnose' -s /bin/sh www-data
 
 For Docker installations, the only requirement to run the diagnose command would be to ensure that you are currently in the same folder as that where the stacks `docker-compose.yml` file lives. If you followed the guides on this website that would be in `/opt/seat-docker`. Next, run the command with:
 
-=== SeAT 4.x
+=== "SeAT 4.x"
 
     ```bash
     docker-compose exec seat-web su -c 'php artisan seat:admin:diagnose' -s /bin/sh www-data
     ```
 
-=== SeAT 5.x
+=== "SeAT 5.x"
     
     ```bash
     docker-compose exec front su -c 'php artisan seat:admin:diagnose' -s /bin/sh www-data


### PR DESCRIPTION
On a few pages, tabs containing instruction for different version are not rendered correctly due to missing quotation marks. This PR fixes these issues.

Old:
![Bildschirmfoto 2023-12-07 um 17 34 09](https://github.com/eveseat/docs/assets/60423027/fc02557e-9cb0-47ca-8676-736edb94de80)

fixed:
![Bildschirmfoto 2023-12-07 um 17 34 26](https://github.com/eveseat/docs/assets/60423027/83523ef0-7f46-4349-b185-e53510820968)
