### PR TITLE
Migrate docker-compose to docker compose

### DIFF
--- a/docs/admin_guides/admin_login.md
+++ b/docs/admin_guides/admin_login.md
@@ -18,7 +18,7 @@ In order to authenticate with built-in admin user, use command disclosed bellow 
 === "Docker (SeAT 5.x)"
     ```bash linenums="1"
     cd /opt/seat-docker
-    docker-compose exec front php artisan seat:admin:login
+    docker compose exec front php artisan seat:admin:login
     ```
 
 === "Bare metal"

--- a/docs/admin_guides/docker_admin.md
+++ b/docs/admin_guides/docker_admin.md
@@ -4,15 +4,26 @@
 
 Occasionally you will need to perform administrative tasks in your SeAT instance running within docker. Be it because you would like to configure TLS for the web interface, change the port of the SeAT webserver or simply generate an admin login URL, this guide aims to help you get familiar for the commands needed for this.
 
-Many of the commands are exactly the same as those used in a bare metal installation, except for the fact that they are always prefixed with `docker-compose` and run from the same directory that you have the seat `docker-compose.yml` file stored. If your `docker-compose.yml` lives in `/opt/seat-docker`, you will need to `cd` to that directory first and then execute the `docker-compose` commands.
+Many of the commands are exactly the same as those used in a bare metal installation, except for the fact that they are always prefixed with `docker compose` and run from the same directory that you have the seat `docker-compose.yml` file stored. If your `docker-compose.yml` lives in `/opt/seat-docker`, you will need to `cd` to that directory first and then execute the `docker compose` commands.
+
+!!! info
+With SeAT 5, we migrated from the `docker-compose` command to `docker compose`. Besides the name, they are fully compatible. If you are still on SeAT 4, you have to use `docker-compose` instead of `docker compose` for all actions. This applies to all actions, not just the ones listed on this page.
 
 ## Container Status
 
 For a quick, birds-eye view on the status of the containers within the SeAT docker stack, the following command may be run:
 
-```bash
-docker-compose ps
-```
+=== "SeAT 4.x"
+
+    ```bash
+    docker-compose ps
+    ```
+
+=== "SeAT 5.x"
+
+    ```bash
+    docker compose ps
+    ```
 
 This should give you the name, entry point, current status and internal ports used within the docker network as output.
 
@@ -24,9 +35,24 @@ Making changes to this file requires the docker stack to be restarted so that th
 
 Once you have made a configuration change, save the `.env` file and restart the stack by simply running the following command from the path where the `docker-compose.yml` lives:
 
-```bash
-docker-compose up -d
-```
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose up -d
+    ```
+
+=== "Docker (SeAT 5.x - using Traefik)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    ```
+
+=== "Docker (SeAT 5.x - using reverse proxy)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    ```
+
 
 ## Live Container Logs
 
@@ -40,23 +66,31 @@ Getting an idea of what is happening inside of the containers may be useful for 
     docker-compose logs --tail 10 -f seat-web
     ```
 
-    All services can referenced by their name using `docker-compose`. You can see the service names [here](https://github.com/eveseat/seat-docker/blob/master/docker-compose.yml). At the time of writing this doc, the available services were: `mariadb`, `redis`, `traefik`, `seat-web`, `seat-worker` and `seat-cron`.
+    All services can referenced by their name using `docker compose`. You can see the service names [here](https://github.com/eveseat/seat-docker/blob/master/docker-compose.yml). At the time of writing this doc, the available services were: `mariadb`, `redis`, `traefik`, `seat-web`, `seat-worker` and `seat-cron`.
 
 === "Docker (SeAT 5.x)"
 
     To view a single services' logs (`front` in this examples case), run:
     
     ```bash
-    docker-compose logs --tail 10 -f front
+    docker compose logs --tail 10 -f front
     ```
 
-    All services can referenced by their name using `docker-compose`. You can see the service names [here](https://github.com/eveseat/seat-docker/blob/master/docker-compose.yml). At the time of writing this doc, the available services were: `mariadb`, `redis`, `traefik`, `front`, `worker` and `scheduler`.
+    All services can referenced by their name using `docker compose`. You can see the service names [here](https://github.com/eveseat/seat-docker/blob/master/docker-compose.yml) and in the adjacent `docker-compose.x.yml` files. At the time of writing this doc, the available services were: `mariadb`, `cache`, `traefik`, `front`, `worker` and `scheduler`.
 
 To view all service logs at once, run:
 
-```bash
-docker-compose logs --tail 10 -f
-```
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose logs --tail 10 -f
+    ```
+
+=== "Docker (SeAT 5.x)"
+
+    ```bash
+    docker compose logs --tail 10 -f
+    ```
 
 Once you are done viewing the output, simply pressing ^C will exit the log viewer.
 
@@ -110,7 +144,7 @@ This directory should have daily log files for you to view.
     If you think your workers may be causing some exceptions, or you want to investigate why they may be failing, you can do so in the `worker` service. Just like for the web UI, get a bash shell and cd to the logs directory.
     
     ```text linenums="1"
-    # docker-compose exec worker bash
+    # docker compose exec worker bash
     root@8ed8967348f1:/var/www/seat# cd storage/logs/
     root@8ed8967348f1:/var/www/seat/storage/logs# ls
     eseye-2020-08-23.log
@@ -136,22 +170,46 @@ Save your `.env` file and run `docker-compose up -d` to restart the stack with t
 
 You can monitor the installation process by running:
 
-```bash
-docker-compose logs --tail 5 -f seat-app
-```
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose logs --tail 10 -f
+    ```
+
+=== "Docker (SeAT 5.x)"
+
+    ```bash
+    docker compose logs --tail 10 -f
+    ```
 
 ## Database Backups and Restore
 
 Backups. They are important and really simple to do. To perform a backup of the current database used within the docker stack, compressing and saving it to a file called `seat_backup.sql.gz`, run:
 
-```bash
-docker-compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"' | gzip > seat_backup.sql.gz
-```
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"' | gzip > seat_backup.sql.gz
+    ```
+
+=== "Docker (SeAT 5.x)"
+
+    ```bash
+    docker compose exec mariadb sh -c 'exec mysqldump "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"' | gzip > seat_backup.sql.gz
+    ```
 
 To restore a backup to a new dockerized instance of SeAT, run:
 
-```bash
-zcat seat_backup.sql.gz | docker-compose exec -T mariadb sh -c 'exec mysql "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"'
-```
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    zcat seat_backup.sql.gz | docker-compose exec -T mariadb sh -c 'exec mysql "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"'
+    ```
+
+=== "Docker (SeAT 5.x)"
+
+    ```bash
+    zcat seat_backup.sql.gz | docker compose exec -T mariadb sh -c 'exec mysql "$MYSQL_DATABASE" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"'
+    ```
 
 [configure SSO]: ../configuration/esi_configuration.md

--- a/docs/configuration/esi_configuration.md
+++ b/docs/configuration/esi_configuration.md
@@ -68,14 +68,14 @@ Your `.env` file is located in `/opt/seat-docker`. Rebuild your app after settin
 
 === "Docker (SeAT 5.x - using Traefik)"
     ```bash linenums="1"
-    docker-compose down
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker compose down
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
     ```
 
 === "Docker (SeAT 5.x - using proxy)"
     ```bash linenums="1"
-    docker-compose down
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker compose down
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
     ```
 
 [EVE Online Developers portal]: https://developers.eveonline.com/applications

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -71,12 +71,12 @@ The more jobs you'll get, the more workers you'll need to process queue in less 
 
 ### Docker Environment
 
-For Docker based installations, all you need is `docker` and `docker-compose`.
-If you already have it installed, check your current version with `docker version` and `docker-compose version` respectively.
+For Docker based installations, all you need is `docker`.
+If you already have it installed, check your current version with `docker version`.
 
-| Type           | Requirement                                              | Version Check            |
-| -------------- | -------------------------------------------------------- | ------------------------ |
-| Docker         | [Docker: ^18.0](https://www.docker.com/)                 | `docker -v`              |
+| Type           | Requirement                              | Version Check            |
+| -------------- |------------------------------------------| ------------------------ |
+| Docker         | [Docker: ^24.0](https://www.docker.com/) | `docker -v`              |
 
 !!! info
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,28 @@ In either case, the next steps to perform when seeing this would be to either [e
 
 > Fatal error: Allowed memory size of #### bytes exhausted (tried to allocate 4096 bytes)...
 
-If you are presented with an error below similar to this after "Updating Dependencies" you must append your .ENV file with `COMPOSER_MEMORY_LIMIT= -1` and run `docker-compose up -d` if you are using docker. Note: spacing is important for this parameter, if you are unsure copy/paste the needed line into your .ENV file.
+If you are presented with an error below similar to this after "Updating Dependencies" you must append your .ENV file with `COMPOSER_MEMORY_LIMIT= -1` and restart the stack with the following if you are using docker:
+
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose up -d
+    ```
+
+=== "Docker (SeAT 5.x - using Traefik)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    ```
+
+=== "Docker (SeAT 5.x - using reverse proxy)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    ```
+
+!!! note
+    Note: spacing is important for this parameter, if you are unsure copy/paste the needed line into your .ENV file.
 
 ## Enabling Debug Mode
 
@@ -42,7 +63,27 @@ The change would immediately take effect and you can simply reload the failed re
 
 If you installed using Docker, cd to the directory where the `docker-compose.yml` file is located. Assuming you followed the guides on this website, that would be in `/opt/seat-docker`. Next, open the `.env` file in a text editor and modify the line that says `APP_DEBUG=false` to say `APP_DEBUG=true`.
 
-For the change to take effect, you need to reload the stack with `docker-compose up -d` from within the same folder. The containers will take a few moments to settle down after which you can reload the failed the request for a detailed error message and code stack trace.
+For the change to take effect, you need to reload the stack:
+
+=== "Docker (SeAT 4.x)"
+
+    ```bash
+    docker-compose up -d
+    ```
+
+=== "Docker (SeAT 5.x - using Traefik)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    ```
+
+=== "Docker (SeAT 5.x - using reverse proxy)"
+
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    ```
+
+The containers will take a few moments to settle down after which you can reload the failed the request for a detailed error message and code stack trace.
 
 ## Checking Log Files
 
@@ -81,7 +122,7 @@ First, enter get a shell within the `seat-web`/`front` container while in the `/
 === "SeAT 5.x"
 
     ```bash
-    docker-compose exec front sh
+    docker compose exec front sh
     ```
 
 Next, tail the log files you want to see.
@@ -123,5 +164,5 @@ For Docker installations, the only requirement to run the diagnose command would
 === "SeAT 5.x"
     
     ```bash
-    docker-compose exec front su -c 'php artisan seat:admin:diagnose' -s /bin/sh www-data
+    docker compose exec front su -c 'php artisan seat:admin:diagnose' -s /bin/sh www-data
     ```


### PR DESCRIPTION
On SeAT 5, the installation instructions use `docker compose` instead of the legacy `docker-compose`. This PR updates all usages of `docker-compose` to `docker compose` for SeAT 5