### PR TITLE
fix -d up to up -d

### DIFF
--- a/docs/admin_guides/docker_admin.md
+++ b/docs/admin_guides/docker_admin.md
@@ -44,13 +44,13 @@ Once you have made a configuration change, save the `.env` file and restart the 
 === "Docker (SeAT 5.x - using Traefik)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using reverse proxy)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```
 
 

--- a/docs/community_packages.md
+++ b/docs/community_packages.md
@@ -79,13 +79,13 @@ SEAT_PLUGINS=denngarr/seat-fitting,cryptaeve/seat-squad-sync
 === "Docker (SeAT 5.x - using Traefik)"
 
     ```bash
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using reverse proxy)"
 
     ```bash
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```
 
 After running the above command wait for containers affected to rebuild. If SeAT does not come back up refer to [Troubleshooting](https://eveseat.github.io/docs/troubleshooting/) for more insight.
@@ -207,7 +207,7 @@ Sometimes it can be useful to install a version different from the latest versio
     
     ```bash linenums="1"
     docker-compose down
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using proxy)"
@@ -221,5 +221,5 @@ Sometimes it can be useful to install a version different from the latest versio
     
     ```bash linenums="1"
     docker-compose down
-    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```

--- a/docs/configuration/esi_configuration.md
+++ b/docs/configuration/esi_configuration.md
@@ -69,13 +69,13 @@ Your `.env` file is located in `/opt/seat-docker`. Rebuild your app after settin
 === "Docker (SeAT 5.x - using Traefik)"
     ```bash linenums="1"
     docker compose down
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using proxy)"
     ```bash linenums="1"
     docker compose down
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```
 
 [EVE Online Developers portal]: https://developers.eveonline.com/applications

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -62,7 +62,7 @@ An example of adding these to your Web UI container is provided below:
     #      - /opt/seat-docker/custom/custom-layout.css:/var/www/seat/public/custom-layout.css
     ```
 
-    Once you have placed the files you will need to run `docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up` for it to take effect.
+    Once you have placed the files you will need to run `docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d` for it to take effect.
 
 === "SeAT 5 (using proxy)"
 
@@ -77,7 +77,7 @@ An example of adding these to your Web UI container is provided below:
     #      - /opt/seat-docker/custom/custom-layout.css:/var/www/seat/public/custom-layout.css
     ```
 
-    Once you have placed the files you will need to run `docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up` for it to take effect.
+    Once you have placed the files you will need to run `docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d` for it to take effect.
 
 An example of a customized login page using `custom-layout-mini.css` would be:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,13 +31,13 @@ If you are presented with an error below similar to this after "Updating Depende
 === "Docker (SeAT 5.x - using Traefik)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using reverse proxy)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```
 
 !!! note
@@ -74,13 +74,13 @@ For the change to take effect, you need to reload the stack:
 === "Docker (SeAT 5.x - using Traefik)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.traefik.yml up -d
     ```
 
 === "Docker (SeAT 5.x - using reverse proxy)"
 
     ```bash
-    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml -d up
+    docker compose -f docker-compose.yml -f docker-compose.mariadb.yml -f docker-compose.proxy.yml up -d
     ```
 
 The containers will take a few moments to settle down after which you can reload the failed the request for a detailed error message and code stack trace.


### PR DESCRIPTION
A typo sneaked in in my last PR: All occurrences of `docker compose ... up -d` were erroneously `docker compose ... -d up`