### PR TITLE
Seat 5 Upgrade: download .env.example instead of .env

### DIFF
--- a/docs/upgrading/from_seat_4_0/docker.md
+++ b/docs/upgrading/from_seat_4_0/docker.md
@@ -247,7 +247,7 @@ some of them have been removed, newest appeared and overall have been reordered.
 
 ```bash linenums="1"
 mv .env .env.seat4.bak
-curl -L https://raw.githubusercontent.com/eveseat/seat-docker/master/.env -o .env
+curl -L https://raw.githubusercontent.com/eveseat/seat-docker/master/.env.example -o .env
 ```
 
 You can refer at any time to the online version of `.env` file on [GitHub](https://github.com/eveseat/seat-docker/blob/master/.env)


### PR DESCRIPTION
The guide instructs user to download a file that doesn't exist. This PR fixes that.